### PR TITLE
add docker config, --all flag, refacto master logic to use env vars i…

### DIFF
--- a/DockerfileParent
+++ b/DockerfileParent
@@ -1,0 +1,62 @@
+FROM fedora:38 AS builder
+
+ENV VCPKG_ROOT=/opt/vcpkg
+ENV PATH=$PATH:$VCPKG_ROOT
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+
+RUN dnf update -y && \
+    dnf install -y \
+    git \
+    gcc \
+    gcc-c++ \
+    cmake \
+    ninja-build \
+    curl
+
+RUN unzip \
+    zip \
+    tar \
+    pkgconfig \
+    which \
+    make \
+    python3 \
+    python3-pip \
+    glib2-devel \
+    libfl-devel \
+    openssl-devel \
+    librdkafka-devel \
+    boost-devel
+
+RUN git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT && \
+    cd $VCPKG_ROOT && \
+    ./bootstrap-vcpkg.sh -useSystemBinaries
+
+RUN pip3 install pyyaml
+
+RUN dnf install -y godot
+
+# //////////////////////////////
+FROM alpine:latest
+
+COPY --from=builder /opt/vcpkg /opt/vcpkg
+COPY --from=builder /usr/bin/godot /usr/bin/godot
+COPY --from=builder /usr/bin/c++ /usr/bin/c++
+COPY --from=builder /usr/bin/gcc /usr/bin/gcc
+COPY --from=builder /usr/lib64 /usr/lib64
+COPY --from=builder /lib64 /lib64
+
+ENV VCPKG_ROOT=/opt/vcpkg
+ENV PATH=$PATH:/opt/vcpkg
+ENV GODOT_PATH=/usr/bin/
+
+RUN apk add --no-cache \
+    libstdc++ \
+    libc6-compat \
+    openssl \
+    curl \
+    bash \
+    python3
+
+CMD ["/bin/bash"]

--- a/automations/run
+++ b/automations/run
@@ -47,9 +47,9 @@ def get_ip_address():
 
 def run_docker_pulsar():
     global current_process
-    env['DOCKER_HOST_IP'] = ip_address
     os.chdir('pulsar')
-    current_process = subprocess.Popen(['docker', 'compose', 'down', '-v'])
+    env['DOCKER_HOST_IP'] = "localhost"
+    current_process = subprocess.Popen(['docker', 'compose', 'down', '-v'], env=env)
     current_process.wait()
     current_process = subprocess.Popen(['docker', 'compose', 'up'], env=env)
     current_process.wait()
@@ -231,7 +231,7 @@ def run_redis_sentinel():
     """Run the Redis Sentinel Docker container."""
     # write the EXTERNAL_HOST_IP to the .env file inside the redis file
     os.chdir('redis')
-    export_env_vars('EXTERNAL_HOST', ip_address)
+    export_env_vars('DOCKER_HOST_IP', ip_address)
     print(f"{Fore.GREEN}Redis Sentinel is running, don't forget to go to http://localhost:5540 and http://localhost:5050 ;){Style.RESET_ALL}")
     subprocess.run(['docker', 'compose', 'down'])
     subprocess.run(['docker', 'compose', 'up'])
@@ -239,20 +239,13 @@ def run_redis_sentinel():
 
 def run_master():
     """Run the master configuration update."""
+    os.environ['DOCKER_HOST_IP'] = ip_address
+    os.environ['PULSAR_BROKERS'] = f"pulsar://{ip_address}:6650"
+    os.environ['REDIS_HOST'] = f"{ip_address}:6379"
+
     os.chdir('master')
-
-    config_file_path = 'configFile.yml'
-    with open(config_file_path, 'r') as f:
-        config = yaml.safe_load(f)
-
-    if 'kafka_brokers' in config:
-        config['kafka_brokers'] = f"{ip_address}:80"
-
-    # Write the updated configuration back to the file
-    with open(config_file_path, 'w') as f:
-        yaml.dump(config, f)
-
     subprocess.run(['dotnet', 'run', '--config', 'configFile.yml'])
+    os.chdir('..')
 
 def run_tests(yaml_path):
     """Run tests defined in the YAML file."""
@@ -410,6 +403,22 @@ def run_tests(yaml_path):
             cluster_process_handle.wait()
             docker_down.wait()
 
+def run_all():
+    export_env_vars('DOCKER_HOST_IP', ip_address)
+    export_env_vars('PULSAR_BROKERS', f"pulsar://{ip_address}:6650")
+    export_env_vars('REDIS_HOST', f"{ip_address}:6379")
+    env['DOCKER_HOST_IP'] = ip_address
+    env['PULSAR_BROKERS'] = f"pulsar://{ip_address}:6650"
+    env['REDIS_HOST'] = f"{ip_address}:6379"
+    os.environ['DOCKER_HOST_IP'] = ip_address
+    os.environ['PULSAR_BROKERS'] = f"pulsar://{ip_address}:6650"
+    os.environ['REDIS_HOST'] = f"{ip_address}:6379"
+
+    print(f"{Fore.GREEN}Running all services with env : {env}{Style.RESET_ALL}")
+    subprocess.run(['docker', 'compose', 'down'])
+    print("env is : ", env)
+    subprocess.run(['docker', 'compose', 'up', '--no-deps', '--build'], env=env)
+
 def run_server():
     """Placeholder method to simulate running a server."""
     print("Server is running...")
@@ -437,6 +446,7 @@ launcher = {
     '--test': run_tests,
     '--redis': run_redis_sentinel,
     '--master': run_master,
+    '--all': run_all,
 }
 
 def usage():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,248 @@
+networks:
+  pulsar:
+    driver: bridge
+
+services:
+  master1:
+    build:
+      context: ./master
+      dockerfile: Dockerfile
+    container_name: master1
+    restart: on-failure
+    environment:
+      - REDIS_HOST=${REDIS_HOST}
+      - PULSAR_BROKERS=${PULSAR_BROKERS}
+      - DOCKER_HOST_IP=${DOCKER_HOST_IP}
+
+  master2:
+    build:
+      context: ./master
+      dockerfile: Dockerfile
+    container_name: master2
+    restart: on-failure
+    environment:
+      - REDIS_HOST=${REDIS_HOST}
+      - PULSAR_BROKERS=${PULSAR_BROKERS}
+      - DOCKER_HOST_IP=${DOCKER_HOST_IP}
+
+  master3:
+    build:
+      context: ./master
+      dockerfile: Dockerfile
+    container_name: master3
+    restart: on-failure
+    environment:
+      - REDIS_HOST=${REDIS_HOST}
+      - PULSAR_BROKERS=${PULSAR_BROKERS}
+      - DOCKER_HOST_IP=${DOCKER_HOST_IP}
+    depends_on:
+      - redis_master
+      - redis_slave
+      - sentinel
+      - redisinsight
+      - zookeeper
+      - pulsar-init
+      - bookie
+      - broker
+
+  # redis:
+  redis_master:
+    image: redis/redis-stack:latest
+    container_name: redis_master
+    restart: on-failure
+    ports:
+      - '6379:6379'
+
+  redis_slave:
+    image: redis/redis-stack:latest
+    container_name: redis_slave
+    command: redis-server --port 6380 --replicaof redis_master 6379
+    restart: on-failure
+    ports:
+      - '6380:6380'
+
+  sentinel:
+    build: ./redis/sentinel
+    container_name: redis_sentinel
+    restart: on-failure
+    ports:
+      - '26379:26379'
+    environment:
+      - SENTINEL_NAME=mysentinel
+      - HOST_IP="${DOCKER_HOST_IP}"
+
+  redisinsight:
+    image: redis/redisinsight:latest
+    container_name: redisinsight
+    restart: on-failure
+    ports:
+      - '5540:5540'
+    environment:
+      - REDIS_URI=redis://redis_master:6379
+
+  redis-commander:
+    container_name: redis-commander
+    hostname: redis-commander
+    image: ghcr.io/joeferner/redis-commander:latest
+    restart: always
+    environment:
+      - REDIS_HOSTS=local:redis_master:6379,local:redis_slave:6380
+    ports:
+      - "5050:8081"
+    user: redis
+# ///////////////////////////////////////
+  # pulsar:
+  zookeeper:
+    image: apachepulsar/pulsar:latest
+    container_name: zookeeper
+    hostname: zookeeper
+    restart: on-failure
+    networks:
+      - pulsar
+    volumes:
+      - ./data/zookeeper:/pulsar/data/zookeeper
+    environment:
+      - metadataStoreUrl=zk:zookeeper:2181
+      - PULSAR_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m
+    ports:
+      - "2181:2181"
+    command: >
+      bash -c "bin/apply-config-from-env.py conf/zookeeper.conf && \
+             bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
+             exec bin/pulsar zookeeper"
+    healthcheck:
+      test: ["CMD", "bin/pulsar-zookeeper-ruok.sh"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
+  # Init cluster metadata
+  pulsar-init:
+    container_name: pulsar-init
+    hostname: pulsar-init
+    image: apachepulsar/pulsar:latest
+    networks:
+      - pulsar
+    command: >
+      bin/pulsar initialize-cluster-metadata --cluster cluster-a --zookeeper zookeeper:2181 --configuration-store zookeeper:2181 --web-service-url http://broker:8080 --broker-service-url pulsar://broker:6650
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+
+  # Start bookie
+  bookie:
+    image: apachepulsar/pulsar:latest
+    container_name: bookie
+    hostname: bookie
+    restart: on-failure
+    networks:
+      - pulsar
+    environment:
+      - clusterName=cluster-a
+      - zkServers=zookeeper:2181
+      - metadataServiceUri=metadata-store:zk:zookeeper:2181
+      # otherwise every time we run docker compose uo or down we fail to start due to Cookie
+      # See: https://github.com/apache/bookkeeper/blob/405e72acf42bb1104296447ea8840d805094c787/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java#L57-68
+      - advertisedAddress=bookie
+      - BOOKIE_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+      pulsar-init:
+        condition: service_completed_successfully
+    # Map the local directory to the container to avoid bookie startup failure due to insufficient container disks.
+    volumes:
+      - ./data/bookkeeper:/pulsar/data/bookkeeper
+    ports:
+      - "3181:3181"
+    command: bash -c "bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
+
+  # Start broker
+  broker:
+    image: apachepulsar/pulsar:latest
+    container_name: broker
+    hostname: broker
+    restart: on-failure
+    networks:
+      - pulsar
+    environment:
+      - metadataStoreUrl=zk:zookeeper:2181
+      - zookeeperServers=zookeeper:2181
+      - clusterName=cluster-a
+      - managedLedgerDefaultEnsembleSize=1
+      - managedLedgerDefaultWriteQuorum=1
+      - managedLedgerDefaultAckQuorum=1
+      - advertisedAddress=broker
+      - advertisedListeners=external:pulsar://127.0.0.1:6650
+      # - advertisedListeners=pulsar://broker:6650
+      - PULSAR_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+      bookie:
+        condition: service_started
+    ports:
+      - "6650:6650"
+      - "8080:8080"
+    command: bash -c "bin/apply-config-from-env.py conf/broker.conf && exec bin/pulsar broker"
+
+  pulsar-express:
+    image: bbonnin/pulsar-express
+    container_name: pulsar-express
+    networks:
+      - pulsar
+    ports:
+      - "9000:3000"
+    environment:
+      - PE_CONNECTION_URL=http://${DOCKER_HOST_IP}:8080
+    depends_on:
+      - broker
+
+  cleanup:
+    image: apachepulsar/pulsar:latest
+    container_name: cleanup
+    hostname: cleanup
+    networks:
+      - pulsar
+    depends_on:
+      - broker
+    entrypoint: >
+      sh -c "
+      bin/pulsar-admin topics list public/default | xargs -I {} bin/pulsar-admin topics delete {}"
+
+  dekaf:
+    image: tealtools/dekaf:latest
+    container_name: dekaf
+    networks:
+      - pulsar
+    ports:
+      - "8090:8090"
+    environment:
+      - DEKAF_PULSAR_BROKER_URL=pulsar://broker:6650
+      - DEKAF_PULSAR_WEB_URL=http://broker:8080
+    depends_on:
+      - broker
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - pulsar
+    volumes:
+      - ./pulsar/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
+      - --web.enable-admin-api
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - pulsar
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=eliotisthebest
+    volumes:
+      - ./grafana:/var/lib/grafana

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -13,7 +13,4 @@ COPY . .
 WORKDIR /master
 
 # Set the entry point for the container
-# dotnet run --config configFile.yml
-# go to /master and run the app
-
 ENTRYPOINT ["dotnet", "run", "--config", "configFile.yml"]

--- a/master/configFile.yml
+++ b/master/configFile.yml
@@ -1,9 +1,3 @@
-container_image: masterceltearm
-cpu: 1
 grapes:
 - LeChateauDuMechant
 - LeChateauDuGentil
-kafka_brokers: 192.168.0.45:80
-memory: 512
-pulsar_brokers: pulsar://localhost:6650
-redis_host: localhost:6379

--- a/master/docker-compose.yml
+++ b/master/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  master:
+    build:
+      context: ./master
+      dockerfile: Dockerfile
+    # /heatlh is the endpoint use by k8s
+    # the master will respond with a 200 status code if it is ready
+  healthcheck:
+    image: nginx:latest
+    container_name: healthcheck
+    ports:
+      - '8080:80'
+    command: /bin/sh -c "while true; do echo 'HTTP/1.1 200 OK\n\n'; sleep 1; done"
+
+

--- a/master/src/config/SetupConfig.cs
+++ b/master/src/config/SetupConfig.cs
@@ -37,32 +37,16 @@ class SetupConfig
         GetNumberOfGrapes();
     }
 
-    public void SettingUpLocal()
-    {
-        if (_yamlObject != null)
-        {
-            int nGrapes = _grapes.Count;
-            Console.WriteLine($"Launching {nGrapes} containers...");
-
-            for (int i = 0; i < nGrapes; i++)
-            {
-                dockerSystem.LaunchContainer().Wait();
-            }
-        }
-        else
-        {
-            Console.WriteLine("Failed to load the configuration file.");
-        }
-    }
-
     private int GetNumberOfGrapes()
     {
+        // Console.WriteLine($"Getting number of grapes...: {_yamlObject["grapes"]}");
         if (_yamlObject != null && _yamlObject.ContainsKey("grapes"))
         {
             var grapes = _yamlObject["grapes"] as List<object>;
             if (grapes != null)
             {
                 _grapes = grapes.Select(g => g.ToString()).ToList();
+                Console.WriteLine($"Number of grapes: {grapes.Count}");
                 return grapes.Count;
             }
         }

--- a/master/src/master/Master.cs
+++ b/master/src/master/Master.cs
@@ -6,7 +6,6 @@ class Master
     public PulsarProducer pulsarProducer;
     public CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
     public RPC rpc = new RPC();
-    public string redisIp;
 
     private Master()
     {
@@ -20,10 +19,10 @@ class Master
             {
                 _master = this;
             }
+            // DotEnv.Load("../.env");
             _setupConfig = new SetupConfig(Environment.GetCommandLineArgs());
             _setupConfig.SettingUpMaster();
-            redisIp = _setupConfig.GetYamlObjectConfig()?["redis_host"]?.ToString() ?? "localhost:6379";
-            Redis.RedisClient redisClient = Redis.RedisClient.GetInstance(redisIp);
+            Redis.RedisClient redisClient = Redis.RedisClient.GetInstance();
             pulsarConsumer = new PulsarConsumer();
             pulsarProducer = new PulsarProducer();
             StartPulsarConsumer();

--- a/master/src/pulsarSteam/consumer/PulsarConsumer.cs
+++ b/master/src/pulsarSteam/consumer/PulsarConsumer.cs
@@ -22,7 +22,9 @@ class PulsarConsumer
     public PulsarConsumer()
     {
         Master master = Master.GetInstance();
-        string pulsarBrokers = master._setupConfig.GetYamlObjectConfig()?["pulsar_brokers"]?.ToString() ?? string.Empty;
+        // string pulsarBrokers = master._setupConfig.GetYamlObjectConfig()?["pulsar_brokers"]?.ToString() ?? string.Empty;
+        // get ip from env
+        string pulsarBrokers = Environment.GetEnvironmentVariable("PULSAR_BROKERS") ?? string.Empty;
         if (string.IsNullOrEmpty(pulsarBrokers))
         {
             throw new ArgumentException("Pulsar brokers are not set.");

--- a/master/src/pulsarSteam/producer/PulsarProducer.cs
+++ b/master/src/pulsarSteam/producer/PulsarProducer.cs
@@ -12,16 +12,14 @@ class PulsarProducer
     {
         try
         {
-            var configObject = master._setupConfig?.GetYamlObjectConfig();
-            if (configObject == null || configObject["pulsar_brokers"] == null)
+            string pulsarBrokers = Environment.GetEnvironmentVariable("PULSAR_BROKERS") ?? string.Empty;
+            if (string.IsNullOrEmpty(pulsarBrokers))
             {
-                throw new InvalidOperationException("Configuration object is null");
+                throw new ArgumentException("Pulsar brokers are not set.");
             }
-            var pulsarConfig = configObject["pulsar_brokers"];
-            string pulsar_brokers = pulsarConfig?.ToString() ?? throw new InvalidOperationException("Pulsar brokers configuration is null");
-            Uri uri = new Uri(pulsar_brokers);
+            Uri uri = new Uri(pulsarBrokers);
             _client = new PulsarClientBuilder()
-                .ServiceUrl(pulsar_brokers)
+                .ServiceUrl(pulsarBrokers)
                 .BuildAsync().Result;
         }
         catch (Exception e)

--- a/master/src/redis/RedisClient.cs
+++ b/master/src/redis/RedisClient.cs
@@ -2,7 +2,6 @@ using StackExchange.Redis;
 using Newtonsoft.Json;
 using System.Text.Json;
 
-
 namespace Redis {
     /// <summary>
     /// Represents a log entry
@@ -25,9 +24,10 @@ namespace Redis {
         public RedisData redisData;
         public RLogger rLogger;
 
-        private RedisClient(string connectionString)
+        private RedisClient()
         {
             try {
+                string connectionString = Environment.GetEnvironmentVariable("REDIS_HOST") ?? string.Empty;
                 _connection = ConnectionMultiplexer.Connect(connectionString);
                 _db = _connection.GetDatabase();
                 Console.WriteLine("Connected to Redis\n");
@@ -36,15 +36,16 @@ namespace Redis {
             }
         }
 
-        public static RedisClient GetInstance(string connectionString = "localhost:6379")
+        public static RedisClient GetInstance()
         {
             if (_instance == null)
             {
+                string connectionString = Environment.GetEnvironmentVariable("REDIS_HOST") ?? string.Empty;
                 if (string.IsNullOrEmpty(connectionString))
                 {
                     throw new ArgumentNullException("Connection string cannot be null or empty");
                 }
-                _instance = new RedisClient(connectionString);
+                _instance = new RedisClient();
                 RedisData Rd = new RedisData(_instance.GetDatabase());
                 _instance.redisData = Rd;
                 RLogger Rl = new RLogger(_instance.GetDatabase());

--- a/master/src/rpc/RPC.cs
+++ b/master/src/rpc/RPC.cs
@@ -138,6 +138,7 @@ public class RPC
         {
             string clientId = args.GetProperty("clientId").GetString();
             string grapeId = args.GetProperty("grapeId").GetString();
+            
             float x = args.GetProperty("x").GetSingle();
             float y = args.GetProperty("y").GetSingle();
             float z = args.GetProperty("z").GetSingle();


### PR DESCRIPTION
### Summary:

This pull request includes several changes to the Docker setup, environment variable handling, and configuration management in the codebase. 
The PR include:

- Add `DockerfileParent`, a dockerfile that contain all the necesary packages to run the SN inside docker later -> passed from 14giga image to 3.5giga 🎉 !
- Updates to environment variable handling in the `automations/run` script, 
- And add of the`docker-compose.yml` file to use 3 * master, pulsar, redis, with one command

⚠️ Some changes has been made on the configuration page, the `master/configFile.yml` only contain the `grapes` now.


### Configuration management:

* Removed hardcoded configuration values from `master/configFile.yml` and updated the code to fetch configurations from environment variables instead. [[1]](diffhunk://#diff-bf4a5b949cdaa83a17ac117b9eb343ef2102ed3b545bf8e28c667240bc9c3fe2L1-L9) [[2]](diffhunk://#diff-f7cc946a3fda24b72fbb033f735c3a41b473e6a8f21183dbdbc39043cddb96f2L25-R27) [[3]](diffhunk://#diff-8e10bb0b5c018ca007db592c5b9762d70358345ca479b2c8d3b2ee4dd6020207L15-R22)
* Updated the `RedisClient` class to use environment variables for the Redis connection string, removing the dependency on the configuration file. [[1]](diffhunk://#diff-c9478e88e8a11af66be6d9ecef9ae1b045fef4b4e443da91cd203161e66ae248L28-R30) [[2]](diffhunk://#diff-c9478e88e8a11af66be6d9ecef9ae1b045fef4b4e443da91cd203161e66ae248L39-R48)

### To test:
To test this changes, you have to use the `./automation/run --all` command and launch a client/server

To compile the parent container: 
- on mac: `docker buildx build --platform linux/amd64 -t sdk-1 -f DockerfileParent --output type=docker .`
- Linux : `docker build -t sdk-1 -f DockerfileParent .`
