### PR TITLE
150 container unload on custom condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv
 __pycache__
 *.db
 pulsar
+celte-godot

--- a/master/src/Program.cs
+++ b/master/src/Program.cs
@@ -44,7 +44,6 @@ class Program
                     Redis.RedisClient redis = Redis.RedisClient.GetInstance();
                     redis.redisData.JSONRemove("nodes");
                     redis.redisData.JSONRemove("action_logs_master");
-                    redis.redisData.JSONRemove("logs");
                     redis.redisData.JSONRemove("clients_try_to_connect");
                     Environment.Exit(0);
                 }

--- a/system/common_src/AuthorityTransfer.cpp
+++ b/system/common_src/AuthorityTransfer.cpp
@@ -29,6 +29,14 @@ static void __notifyDrop(nlohmann::json args) {
 }
 #endif
 
+static void prettyPrintAuthTransfer(nlohmann::json args) {
+  std::cout << "\n\033[1;32m[AT]:\033[0m entity ";
+  std::cout << args["e"].get<std::string>().substr(0, 4) << " ("
+            << args["f"].get<std::string>().substr(0, 4) << " -> "
+            << args["t"].get<std::string>().substr(0, 4) << ")" << std::endl;
+  std::cout << std::endl;
+}
+
 void AuthorityTransfer::TransferAuthority(const std::string &entityId,
                                           const std::string &toContainerId,
                                           const std::string &payload,
@@ -63,6 +71,7 @@ void AuthorityTransfer::TransferAuthority(const std::string &entityId,
   args["g"] = GHOSTSYSTEM.PeekProperties(entityId).value_or("{}");
 
   LOGGER.log(celte::Logger::DEBUG, "AuthorityTransfer: \n" + args.dump());
+  prettyPrintAuthTransfer(args);
 
   // notify the container that will take authority
   __notifyTakeAuthority(args);
@@ -170,6 +179,11 @@ void AuthorityTransfer::ProxyTakeAuthority(const std::string &grapeId,
                                            const std::string &entityId,
                                            const std::string &fromContainerId,
                                            const std::string &payload) {
+  std::cout << "args for proxy take: \n";
+  std::cout << "\t- grapeId: " << grapeId.substr(0, 7) << std::endl;
+  std::cout << "\t- entityId: " << entityId.substr(0, 4) << std::endl;
+  std::cout << "\t- fromContainerId: " << fromContainerId.substr(0, 4)
+            << std::endl;
   RUNTIME.GetPeerService().GetRPCService().CallVoid(
       tp::peer(grapeId), "__rp_proxyTakeAuthority", entityId, fromContainerId,
       payload);

--- a/system/common_src/AuthorityTransfer.cpp
+++ b/system/common_src/AuthorityTransfer.cpp
@@ -62,8 +62,7 @@ void AuthorityTransfer::TransferAuthority(const std::string &entityId,
   args["payload"] = payload;
   args["g"] = GHOSTSYSTEM.PeekProperties(entityId).value_or("{}");
 
-  std::cout << "\nAUTHORITY TRANSFER:\n";
-  std::cout << args.dump() << std::endl << std::endl;
+  LOGGER.log(celte::Logger::DEBUG, "AuthorityTransfer: \n" + args.dump());
 
   // notify the container that will take authority
   __notifyTakeAuthority(args);
@@ -79,8 +78,6 @@ static void __execDropOrderImpl(Entity &e, const std::string &toContainerId,
                                 const std::string &procedureId) {
   // if toContainerId does not exist here, schedule ett for deletion
   if (!GRAPES.ContainerExists(toContainerId)) {
-    std::cout << "toContainerId does not exist, scheduling for deletion"
-              << std::endl;
     e.isValid = false;
     e.quarantine = true;
     // TODO schedule ett for deletion
@@ -96,7 +93,6 @@ static void __execDropOrderImpl(Entity &e, const std::string &toContainerId,
 static void applyGhostToEntity(const std::string &entityId,
                                nlohmann::json ghost) {
   try {
-    std::cout << "auth transfer calling udpate ghost" << std::endl;
     GHOSTSYSTEM.ApplyUpdate(entityId, ghost);
   } catch (const std::exception &e) {
     std::cerr << "Error while applying ghost to entity: " << e.what()
@@ -107,7 +103,6 @@ static void applyGhostToEntity(const std::string &entityId,
 void AuthorityTransfer::ExecTakeOrder(nlohmann::json args) {
   LOGGER.log(celte::Logger::DEBUG,
              "AuthorityTransfer: Executing take order.\n" + args.dump());
-  std::cout << "exec take" << std::endl;
 
   std::string entityId = args["e"].get<std::string>();
   std::string toContainerId = args["t"].get<std::string>();
@@ -116,7 +111,6 @@ void AuthorityTransfer::ExecTakeOrder(nlohmann::json args) {
   std::string when = args["w"].get<std::string>();
   std::string payload = args["payload"].get<std::string>();
   nlohmann::json ghostData = args["g"];
-  std::cout << "unwrapped args" << std::endl;
 
   Clock::timepoint whenTp = Clock::FromISOString(when);
 

--- a/system/common_src/CelteService.cpp
+++ b/system/common_src/CelteService.cpp
@@ -1,3 +1,16 @@
 #include "CelteService.hpp"
 
 using namespace celte::net;
+
+void CelteService::__cleanup() {
+  for (auto &rs : _readerStreams) {
+    rs->Close();
+  }
+  // waiting a few ms so that all reader streams are closed properly and the
+  // last message handler is done running
+  for (auto &rs : _readerStreams) {
+    rs->BlockUntilNoPending();
+  }
+  _readerStreams.clear();
+  _writerStreams.clear();
+}

--- a/system/common_src/Clock.cpp
+++ b/system/common_src/Clock.cpp
@@ -22,7 +22,7 @@ void Clock::Start() {
           }});
 }
 
-void Clock::Stop() { _destroyAllReaderStreams(); }
+void Clock::Stop() { __cleanup(); }
 
 Clock::timepoint Clock::GetUnifiedTime() {
   std::lock_guard<std::mutex> lock(_mutex);

--- a/system/common_src/Config.cpp
+++ b/system/common_src/Config.cpp
@@ -25,7 +25,7 @@ Config::Config() { // Set default values
 
   const char *replication_interval = getenv("REPLICATION_INTERVAL");
   _config["replication_interval"] =
-      replication_interval ? replication_interval : "100";
+      replication_interval ? replication_interval : "33";
 }
 
 std::optional<std::string> Config::Get(const std::string &key) const {

--- a/system/common_src/Container.cpp
+++ b/system/common_src/Container.cpp
@@ -149,7 +149,8 @@ void ContainerRegistry::RunWithLock(const std::string &containerId,
   if (_containers.find(acc, containerId)) {
     f(acc->second);
   } else {
-    std::cerr << "Container not found: " << containerId << std::endl;
+    std::cerr << "Lock on container failed, container was not found: "
+              << containerId << std::endl;
   }
 }
 
@@ -180,6 +181,8 @@ void ContainerRegistry::UpdateRefCount(const std::string &containerId) {
   accessor acc;
   if (_containers.find(acc, containerId)) {
     if (acc->second.container.use_count() == 1) {
+      ETTREGISTRY.DeleteEntitiesInContainer(containerId);
+      RUNTIME.GetTrashBin().TrashItem(std::move(acc->second.GetContainerPtr()));
       _containers.erase(acc);
       LOGDEBUG("Container " + containerId +
                " is no longer referenced and has been deleted.");

--- a/system/common_src/ContainerSubscriptionComponent.cpp
+++ b/system/common_src/ContainerSubscriptionComponent.cpp
@@ -46,8 +46,6 @@ void ContainerSubscriptionComponent::Unsubscribe(
     const std::string &containerId) {
   LOGINFO("Unsubscribing from container " + containerId);
   if (_subscriptions.find(containerId) == _subscriptions.end()) {
-    std::cerr << "Container not found in subscriptions: " << containerId
-              << std::endl;
     return;
   }
   {

--- a/system/common_src/ContainerSubscriptionComponent.cpp
+++ b/system/common_src/ContainerSubscriptionComponent.cpp
@@ -7,7 +7,6 @@ ContainerSubscriptionComponent::Subscribe(const std::string &containerId,
                                           std::function<void()> onReady,
                                           bool isLocallyOwned) {
   LOGINFO("Subscribing to container " + containerId);
-  std::cout << "SUBSCRIBING TO CONTAINER " << containerId << std::endl;
   if (_subscriptions.find(containerId) != _subscriptions.end()) {
     onReady();
     return std::nullopt;
@@ -47,6 +46,8 @@ void ContainerSubscriptionComponent::Unsubscribe(
     const std::string &containerId) {
   LOGINFO("Unsubscribing from container " + containerId);
   if (_subscriptions.find(containerId) == _subscriptions.end()) {
+    std::cerr << "Container not found in subscriptions: " << containerId
+              << std::endl;
     return;
   }
   {

--- a/system/common_src/ETTRegistry.cpp
+++ b/system/common_src/ETTRegistry.cpp
@@ -129,6 +129,8 @@ void ETTRegistry::EngineCallInstantiate(const std::string &id,
 
 void ETTRegistry::LoadExistingEntities(const std::string &grapeId,
                                        const std::string &containerId) {
+  std::cout << "\033[031mLOAD\033[0m foreach in " << containerId.substr(0, 4)
+            << std::endl;
   RUNTIME.GetPeerService()
       .GetRPCService()
       .CallAsync<std::map<std::string, std::string>>(

--- a/system/common_src/ETTRegistry.cpp
+++ b/system/common_src/ETTRegistry.cpp
@@ -8,7 +8,7 @@
 
 using namespace celte;
 
-Entity::~Entity() { GhostSystem::TryRemoveEntity(id); }
+Entity::~Entity() {}
 
 ETTRegistry &ETTRegistry::GetInstance() {
   static ETTRegistry instance;
@@ -32,6 +32,7 @@ void ETTRegistry::UnregisterEntity(const std::string &id) {
           "Cannot unregister a valid entity as it is still in use.");
     }
     _entities.erase(acc);
+    GhostSystem::TryRemoveEntity(id);
   }
 }
 
@@ -129,7 +130,7 @@ void ETTRegistry::EngineCallInstantiate(const std::string &id,
 
 void ETTRegistry::LoadExistingEntities(const std::string &grapeId,
                                        const std::string &containerId) {
-  std::cout << "\033[031mLOAD\033[0m foreach in " << containerId.substr(0, 4)
+  std::cout << "\033[032mLOAD\033[0m foreach in " << containerId.substr(0, 4)
             << std::endl;
   RUNTIME.GetPeerService()
       .GetRPCService()

--- a/system/common_src/ETTRegistry.cpp
+++ b/system/common_src/ETTRegistry.cpp
@@ -236,9 +236,16 @@ void ETTRegistry::UploadInputData(std::string uuid, std::string inputName,
 
 void ETTRegistry::DeleteEntitiesInContainer(const std::string &containerId) {
   std::map<std::string, std::string> toDelete;
+  std::cout << "\033[031mDELETE\033[0m foreach in " << containerId.substr(0, 4)
+            << std::endl;
   for (auto it = _entities.begin(); it != _entities.end(); ++it) {
     accessor acc;
     if (_entities.find(acc, it->first)) {
+      std::cout << "\t["
+                << ((acc->second.ownerContainerId == containerId)
+                        ? "\033[31mx\033[0m"
+                        : "\033[032mV\033[0m")
+                << "] " << it->first.substr(0, 4) << std::endl;
       if (acc->second.ownerContainerId == containerId) {
         acc->second.isValid = false;
         acc->second.quarantine = true;

--- a/system/common_src/GhostSystem.cpp
+++ b/system/common_src/GhostSystem.cpp
@@ -74,8 +74,10 @@ void GhostSystem::UpdatePropertyState(const std::string &eid,
 }
 
 void GhostSystem::ApplyUpdate(const std::string &eid, nlohmann::json &update) {
-  __withPropertyLock(eid, [&update](Properties &props) {
+  __withPropertyLock(eid, [&update, eid](Properties &props) {
     for (auto &[key, value] : update.items()) {
+      std::cout << "(" << eid.substr(0, 4) << ") " << key << " <= " << value
+                << std::endl;
       props.Set(key, value);
     }
   });
@@ -195,5 +197,9 @@ GhostSystem::PeekProperties(const std::string &eid) {
       props.value()[key] = prop.value;
     }
   });
+  if (props.has_value()) {
+    std::cout << "peek properties returns json: \n"
+              << props.value() << std::endl;
+  }
   return props;
 }

--- a/system/common_src/GhostSystem.cpp
+++ b/system/common_src/GhostSystem.cpp
@@ -204,9 +204,5 @@ GhostSystem::PeekProperties(const std::string &eid) {
       props.value()[key] = prop.value;
     }
   });
-  if (props.has_value()) {
-    std::cout << "Peeked properties for " << eid.substr(0, 4) << ": "
-              << props.value().dump() << std::endl;
-  }
   return props;
 }

--- a/system/common_src/GhostSystem.cpp
+++ b/system/common_src/GhostSystem.cpp
@@ -74,7 +74,6 @@ void GhostSystem::UpdatePropertyState(const std::string &eid,
 }
 
 void GhostSystem::ApplyUpdate(const std::string &eid, nlohmann::json &update) {
-  std::cout << "applied update at spawn: " << update.dump() << std::endl;
   __withPropertyLock(eid, [&update](Properties &props) {
     for (auto &[key, value] : update.items()) {
       props.Set(key, value);

--- a/system/common_src/Grape.cpp
+++ b/system/common_src/Grape.cpp
@@ -76,6 +76,9 @@ void Grape::initRPCService() {
                                    return true;
                                  }));
     }
+
+    rpcService->Register<bool>("__rp_ping",
+                               std::function([this](bool) { return true; }));
 #endif
 
     rpcService->Register<bool>(

--- a/system/common_src/Grape.cpp
+++ b/system/common_src/Grape.cpp
@@ -4,6 +4,7 @@
 #endif
 #include "Container.hpp"
 #include "Grape.hpp"
+#include "GrapeRegistry.hpp"
 #include "Logger.hpp"
 #include "PeerService.hpp"
 #include "Runtime.hpp"
@@ -37,18 +38,25 @@ void Grape::initRPCService() {
         std::function<std::vector<std::string>()>(
             [this]() { return __rp_getExistingOwnedContainers(); }));
 
-    rpcService->Register<bool>("__rp_subscribeToContainer",
-                               std::function([this](std::string containerId) {
-                                 subscribeToContainer(
-                                     containerId, []() {}, false);
-                                 return true;
-                               }));
+    rpcService->Register<bool>(
+        "__rp_subscribeToContainer",
+        std::function([this](std::string ownerOfContainerId,
+                             std::string containerId) {
+          GRAPES.RunWithLock(ownerOfContainerId, [this, containerId](Grape &g) {
+            g.subscribeToContainer(containerId, []() {}, false);
+          });
+          return true;
+        }));
 
-    rpcService->Register<bool>("__rp_unsubscribeFromContainer",
-                               std::function([this](std::string containerId) {
-                                 unsubscribeFromContainer(containerId);
-                                 return true;
-                               }));
+    rpcService->Register<bool>(
+        "__rp_unsubscribeFromContainer",
+        std::function([this](std::string ownerOfContainerId,
+                             std::string containerId) {
+          GRAPES.RunWithLock(ownerOfContainerId, [this, containerId](Grape &g) {
+            g.unsubscribeFromContainer(containerId);
+          });
+          return true;
+        }));
 
     if (isLocallyOwned) {
       rpcService->Register<bool>(
@@ -131,10 +139,6 @@ std::vector<std::string> Grape::__rp_getExistingOwnedContainers() {
       result.push_back(containerId);
     }
   }
-  for (auto &c : result) {
-    std::cout << "  - " << c << std::endl;
-  }
-  std::cout << "]" << std::endl;
   return result;
 }
 #endif

--- a/system/common_src/PeerService.cpp
+++ b/system/common_src/PeerService.cpp
@@ -48,16 +48,13 @@ bool PeerService::__waitNetworkReady(
       return false;
     }
   }
-  std::cout << "Peer network is ready" << std::endl;
   return true;
 }
 
 void PeerService::__initPeerRPCs() {
 #ifdef CELTE_SERVER_MODE_ENABLED
-  std::cout << "[[SERVER MODE]]" << std::endl;
   __registerServerRPCs();
 #else
-  std::cout << "[[CLIENT MODE]]" << std::endl;
   __registerClientRPCs();
 #endif
 }
@@ -93,8 +90,6 @@ void PeerService::__registerServerRPCs() {
   _rpcService->Register<std::string>(
       "__rp_getPlayerSpawnPosition",
       std::function([this](std::string clientId) {
-        std::cout << "Requesting spawn position for client " << clientId
-                  << std::endl;
         return __rp_spawnPositionRequest(clientId);
       }));
 
@@ -124,7 +119,6 @@ void PeerService::__registerClientRPCs() {
 
 #ifdef CELTE_SERVER_MODE_ENABLED
 bool PeerService::__rp_assignGrape(const std::string &grapeId) {
-  std::cout << "Assigning grape " << grapeId << std::endl;
   LOGINFO("Taking ownership of grape " + grapeId);
   RUNTIME.SetAssignedGrape(grapeId);
   RUNTIME.TopExecutor().PushTaskToEngine(
@@ -151,11 +145,9 @@ bool PeerService::__rp_acceptNewClient(const std::string &clientId) {
 void PeerService::ConnectClientToThisNode(const std::string &clientId,
                                           std::function<void()> then) {
   try {
-    std::cout << "calling rpc on topic " << tp::rpc(clientId) << std::endl;
     bool ok =
         _rpcService->Call<bool>(tp::rpc(clientId), "__rp_forceConnectToNode",
                                 RUNTIME.GetAssignedGrape());
-    std::cout << "ok: " << ok << std::endl;
     if (ok) {
       RUNTIME.TopExecutor().PushTaskToEngine(then);
     }

--- a/system/common_src/PendingRefClount.cpp
+++ b/system/common_src/PendingRefClount.cpp
@@ -1,0 +1,9 @@
+#include "ReaderStream.hpp"
+
+using namespace celte::net;
+
+PendingRefCount::PendingRefCount(std::atomic_int &counter) : _counter(counter) {
+  ++_counter;
+}
+
+PendingRefCount::~PendingRefCount() { --_counter; }

--- a/system/common_src/ReaderStream.cpp
+++ b/system/common_src/ReaderStream.cpp
@@ -1,0 +1,9 @@
+#include "ReaderStream.hpp"
+
+using namespace celte::net;
+
+void ReaderStream::BlockUntilNoPending() {
+  while (_pendingMessages > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}

--- a/system/common_src/Runtime.cpp
+++ b/system/common_src/Runtime.cpp
@@ -55,7 +55,6 @@ void Runtime::ConnectToCluster(const std::string &address, int port) {
           _hooks.onConnectionFailed();
           return;
         }
-        std::cout << "Connected to cluster" << std::endl;
         _hooks.onConnectionSuccess();
       }));
 #ifdef CELTE_SERVER_MODE_ENABLED
@@ -93,8 +92,6 @@ void Runtime::CallScopedRPCNoRetVal(const std::string &scope,
               << std::endl;
     return;
   }
-  std::cout << "calling scoped rpc with args: " << args << std::endl;
-  std::cout << "topic : " << tp::default_scope + scope << std::endl;
   _peerService->GetRPCService().CallVoid(tp::default_scope + scope, name, args);
 }
 
@@ -143,7 +140,6 @@ void Runtime::ForceDisconnectClient(const std::string &clientId,
 #else
 
 void Runtime::Disconnect() {
-  std::cout << "CLIENT DISCONNECTING FROM SERVER" << std::endl;
   // we send the disconnect message to all grapes
   for (auto &g : GRAPES.GetGrapes()) {
     g.second.rpcService->CallVoid(

--- a/system/common_src/Runtime.cpp
+++ b/system/common_src/Runtime.cpp
@@ -37,11 +37,11 @@ void Runtime::ConnectToCluster() {
   const char *host = std::getenv("CELTE_HOST");
   const char *port = std::getenv("CELTE_PORT");
   std::string address = host ? host : "localhost";
-  if (port) {
-    ConnectToCluster(address, std::stoi(port));
-  } else {
-    ConnectToCluster(address, 6650);
-  }
+  int iport = port ? std::stoi(port) : 6650;
+
+  std::cout << "Connecting to pulsar cluster at " << address << ":" << iport
+            << std::endl;
+  ConnectToCluster(address, iport);
 }
 
 void Runtime::ConnectToCluster(const std::string &address, int port) {

--- a/system/common_src/TrashBin.cpp
+++ b/system/common_src/TrashBin.cpp
@@ -1,0 +1,17 @@
+#include "Runtime.hpp"
+#include "TrashBin.hpp"
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+using namespace celte;
+
+void TrashBin::TrashItem(ITrashable *item) {
+  std::shared_ptr<ITrashable> ptr(item);
+  __asyncCleanup(std::move(ptr));
+}
+
+void TrashBin::__asyncCleanup(std::shared_ptr<ITrashable> item) {
+  RUNTIME.ScheduleAsyncTask(
+      [item = std::move(item)]() mutable { item->__cleanup(); });
+}

--- a/system/common_src/exports.cpp
+++ b/system/common_src/exports.cpp
@@ -218,6 +218,10 @@ EXPORT bool AdvanceGrapeTask(const std::string &grapeId) {
   return false;
 }
 
+EXPORT std::map<std::string, int> GetLatency() {
+  return RUNTIME.GetPeerService().GetLatency();
+}
+
 #pragma endregion
 
 #pragma region NAMED_TASKS

--- a/system/common_src/exports.cpp
+++ b/system/common_src/exports.cpp
@@ -69,6 +69,11 @@ EXPORT void ProcessEntityContainerAssignment(const std::string &entityId,
                                               ignoreNoMove);
 }
 
+EXPORT bool SaveEntityPayload(const std::string &eid,
+                              const std::string &payload) {
+  return ETTREGISTRY.SaveEntityPayload(eid, payload);
+}
+
 #ifdef CELTE_SERVER_MODE_ENABLED
 EXPORT void ConnectClientToThisNode(std::string clientId,
                                     std::function<void()> then) {
@@ -82,15 +87,12 @@ EXPORT void SubscribeClientToContainer(std::string clientId,
                                                       then);
 }
 
-EXPORT bool SaveEntityPayload(const std::string &eid,
-                              const std::string &payload) {
-  return ETTREGISTRY.SaveEntityPayload(eid, payload);
-}
-
-EXPORT void UpdateSubscriptionStatus(const std::string &grapeId,
+EXPORT void UpdateSubscriptionStatus(const std::string &ownerOfContainerId,
+                                     const std::string &grapeId,
                                      const std::string &containerId,
                                      bool subscribe) {
-  GRAPES.SetRemoteGrapeSubscription(grapeId, containerId, subscribe);
+  GRAPES.SetRemoteGrapeSubscription(ownerOfContainerId, grapeId, containerId,
+                                    subscribe);
 }
 
 EXPORT void ProxyTakeAuthority(const std::string &grapeId,

--- a/system/common_src/exports.cpp
+++ b/system/common_src/exports.cpp
@@ -87,6 +87,12 @@ EXPORT void SubscribeClientToContainer(std::string clientId,
                                                       then);
 }
 
+EXPORT void UnsubscribeClientFromContainer(std::string clientId,
+                                           std::string containerId) {
+  RUNTIME.GetPeerService().UnsubscribeClientFromContainer(clientId,
+                                                          containerId);
+}
+
 EXPORT void UpdateSubscriptionStatus(const std::string &ownerOfContainerId,
                                      const std::string &grapeId,
                                      const std::string &containerId,
@@ -143,6 +149,10 @@ EXPORT std::optional<void *> GetETTNativeHandle(const std::string &id) {
 
 EXPORT void ForgetEntityNativeHandle(const std::string &id) {
   ETTREGISTRY.ForgetEntityNativeHandle(id);
+}
+
+EXPORT std::string GetETTOwnerContainerId(const std::string &id) {
+  return ETTREGISTRY.GetEntityOwnerContainer(id);
 }
 
 #ifdef CELTE_SERVER_MODE_ENABLED

--- a/system/common_src/exports.cpp
+++ b/system/common_src/exports.cpp
@@ -32,12 +32,9 @@ EXPORT void RegisterGrape(const std::string &grapeId, bool isLocallyOwned,
 }
 
 #ifdef CELTE_SERVER_MODE_ENABLED
-EXPORT char *ContainerCreateAndAttach(std::string grapeId,
-                                      std::function<void()> onReady,
-                                      size_t *size) {
-  std::string result = GRAPES.ContainerCreateAndAttach(grapeId, onReady);
-  *size = result.size();
-  return strdup(result.c_str());
+EXPORT std::string ContainerCreateAndAttach(const std::string &grapeId,
+                                            std::function<void()> onReady) {
+  return GRAPES.ContainerCreateAndAttach(grapeId, onReady);
 }
 #endif
 
@@ -55,11 +52,7 @@ EXPORT void RegisterNewEntity(const std::string &id,
   });
 }
 
-EXPORT char *GetNewUUID(size_t *size) {
-  std::string uuid = RUNTIME.GenUUID();
-  *size = uuid.size();
-  return strdup(uuid.c_str());
-}
+EXPORT std::string GetNewUUID() { return RUNTIME.GenUUID(); }
 
 EXPORT void ProcessEntityContainerAssignment(const std::string &entityId,
                                              const std::string &toContainerId,
@@ -75,20 +68,20 @@ EXPORT bool SaveEntityPayload(const std::string &eid,
 }
 
 #ifdef CELTE_SERVER_MODE_ENABLED
-EXPORT void ConnectClientToThisNode(std::string clientId,
+EXPORT void ConnectClientToThisNode(const std::string &clientId,
                                     std::function<void()> then) {
   RUNTIME.GetPeerService().ConnectClientToThisNode(clientId, then);
 }
 
-EXPORT void SubscribeClientToContainer(std::string clientId,
-                                       std::string containerId,
+EXPORT void SubscribeClientToContainer(const std::string &clientId,
+                                       const std::string &containerId,
                                        std::function<void()> then) {
   RUNTIME.GetPeerService().SubscribeClientToContainer(clientId, containerId,
                                                       then);
 }
 
-EXPORT void UnsubscribeClientFromContainer(std::string clientId,
-                                           std::string containerId) {
+EXPORT void UnsubscribeClientFromContainer(const std::string &clientId,
+                                           const std::string &containerId) {
   RUNTIME.GetPeerService().UnsubscribeClientFromContainer(clientId,
                                                           containerId);
 }
@@ -272,20 +265,15 @@ EXPORT void CallGlobalRPCNoRetVal(const std::string &name,
   RUNTIME.CallScopedRPCNoRetVal(celte::tp::global_rpc, name, args);
 }
 
-EXPORT [[nodiscard]] char *
-CallGlobalRPC(const std::string &name, const std::string &args, size_t *size) {
-  std::string result = RUNTIME.CallScopedRPC(celte::tp::global_rpc, name, args);
-  *size = result.size();
-  return strdup(result.c_str());
+EXPORT std::string CallGlobalRPC(const std::string &name,
+                                 const std::string &args) {
+  return RUNTIME.CallScopedRPC(celte::tp::global_rpc, name, args);
 }
 
-EXPORT [[nodiscard]] char *CallScopedRPC(const std::string &scope,
-                                         const std::string &name,
-                                         const std::string &args,
-                                         size_t *size) {
-  std::string result = RUNTIME.CallScopedRPC(scope, name, args);
-  *size = result.size();
-  return strdup(result.c_str());
+EXPORT std::string CallScopedRPC(const std::string &scope,
+                                 const std::string &name,
+                                 const std::string &args) {
+  return RUNTIME.CallScopedRPC(scope, name, args);
 }
 
 EXPORT void CallScopedRPCNoRetVal(const std::string &scope,
@@ -310,7 +298,7 @@ EXPORT void SetOnGetClientInitialGrapeHook(
 }
 
 EXPORT void
-SetOnAcceptNewClientHook(std::function<std::string(const std::string &)> f) {
+SetOnAcceptNewClientHook(std::function<void(const std::string &)> f) {
   RUNTIME.Hooks().onAcceptNewClient = f;
 }
 
@@ -332,8 +320,8 @@ EXPORT void SetOnClientNotSeenHook(std::function<void(const std::string &)> f) {
 
 #endif // all peers hooks -------------------------------------------------- */
 
-EXPORT void
-SetOnClientDisconnectHook(std::function<void(std::string, std::string)> f) {
+EXPORT void SetOnClientDisconnectHook(
+    std::function<void(const std::string &, const std::string &)> f) {
   RUNTIME.Hooks().onClientDisconnect = f;
 }
 
@@ -363,13 +351,14 @@ EXPORT void SetOnDeleteEntityHook(
   RUNTIME.Hooks().onDeleteEntity = f;
 }
 
-EXPORT void UploadInputData(std::string uuid, std::string inputName,
-                            bool pressed, float x = 0, float y = 0) {
+EXPORT void UploadInputData(const std::string &uuid,
+                            const std::string &inputName, bool pressed,
+                            float x = 0, float y = 0) {
   ETTREGISTRY.UploadInputData(uuid, inputName, pressed, x, y);
 }
 
 EXPORT std::optional<const celte::CelteInputSystem::INPUT>
-GetInputCircularBuf(std::string uuid, std::string InputName) {
+GetInputCircularBuf(const std::string &uuid, const std::string &InputName) {
   return CINPUT.GetInputCircularBuf(uuid, InputName);
 }
 

--- a/system/include/CelteService.hpp
+++ b/system/include/CelteService.hpp
@@ -2,6 +2,7 @@
 #include "CelteNet.hpp"
 #include "ReaderStream.hpp"
 #include "Runtime.hpp"
+#include "TrashBin.hpp"
 #include "WriterStream.hpp"
 #include "nlohmann/json.hpp"
 #include "pulsar/Schema.h"
@@ -13,7 +14,7 @@ namespace net {
 // This class is the base class for all network services. It provides basic
 // functionality for connecting to the network and sending and receiving
 // messages, and creating a stream of messages.
-class CelteService {
+class CelteService : public ITrashable {
 public:
   inline std::optional<std::shared_ptr<WriterStream>>
   GetWriterStream(const std::string &topic) {
@@ -22,16 +23,10 @@ public:
     return _writerStreams[topic];
   }
 
+  /// @brief overrides ITrashable __cleanup.
+  void __cleanup() override;
+
 protected:
-  inline void _destroyReaderStream(std::shared_ptr<ReaderStream> stream) {
-    _readerStreams.erase(
-        std::remove_if(_readerStreams.begin(), _readerStreams.end(),
-                       [stream](auto &s) { return s == stream; }),
-        _readerStreams.end());
-  }
-
-  inline void _destroyAllReaderStreams() { _readerStreams.clear(); }
-
   inline void _destroyWriterStream(const std::string &topic) {
     _writerStreams.erase(topic);
   }

--- a/system/include/ClientRegistry.hpp
+++ b/system/include/ClientRegistry.hpp
@@ -17,6 +17,7 @@ struct ClientData {
   std::chrono::time_point<std::chrono::system_clock> lastSeen;
   bool isLocallyOwned;
   std::string currentOwnerGrape;
+  std::chrono::milliseconds latency;
 
 #ifdef CELTE_SERVER_MODE_ENABLED
   inline bool isSubscribedToContainer(const std::string &containerId) {

--- a/system/include/Container.hpp
+++ b/system/include/Container.hpp
@@ -102,6 +102,8 @@ public:
     /// may be invalidated.
     inline Container &GetContainer() { return *container; }
 
+    inline std::shared_ptr<Container> GetContainerPtr() { return container; }
+
     void IncRefCount() { refCount.fetch_add(1, std::memory_order_relaxed); }
 
     void DecRefCount() { refCount.fetch_sub(1, std::memory_order_relaxed); }

--- a/system/include/ETTRegistry.hpp
+++ b/system/include/ETTRegistry.hpp
@@ -33,6 +33,11 @@ public:
   /// context of the engine.
   std::optional<std::function<void()>> PollEngineTask(const std::string &id);
 
+  /// @brief Calls the delete entity hook on all entities owned by the container
+  /// whose id is passed in argument.
+  /// @param containerId
+  void DeleteEntitiesInContainer(const std::string &containerId);
+
   inline storage &GetEntities() { return _entities; }
 
   /// @brief Instantiates an entity in the engine by calling the
@@ -112,6 +117,7 @@ public:
   /// onInstantiateEntity hook in the engine.
   void LoadExistingEntities(const std::string &grapeId,
                             const std::string &containerId);
+  bool SaveEntityPayload(const std::string &eid, const std::string &payload);
 
 #ifdef CELTE_SERVER_MODE_ENABLED
 
@@ -120,7 +126,6 @@ public:
   /// @param containerId
   std::map<std::string, std::string>
   GetExistingEntities(const std::string &containerId);
-  bool SaveEntityPayload(const std::string &eid, const std::string &payload);
   std::expected<std::string, std::string>
   GetEntityPayload(const std::string &eid);
 

--- a/system/include/ETTRegistry.hpp
+++ b/system/include/ETTRegistry.hpp
@@ -1,7 +1,8 @@
 #pragma once
-
 #include "Entity.hpp"
+#include <exception>
 #include <expected>
+#include <iostream>
 #include <map>
 #include <optional>
 #include <string>
@@ -10,6 +11,18 @@
 #define ETTREGISTRY celte::ETTRegistry::GetInstance()
 
 namespace celte {
+
+class ETTAlreadyRegisteredException : public std::exception {
+public:
+  ETTAlreadyRegisteredException(const std::string &id)
+      : _id(id), _msg("Entity with id " + id + " already exists.") {}
+
+  const char *what() const noexcept override { return _msg.c_str(); }
+
+private:
+  std::string _id;
+  std::string _msg;
+};
 
 class ETTRegistry {
 public:
@@ -49,8 +62,7 @@ public:
   /// @brief Runs a function with a lock on the entity.
   /// @param id
   /// @param f
-  inline void RunWithLock(const std::string &id,
-                          std::function<void(Entity &)> f) {
+  void RunWithLock(const std::string &id, std::function<void(Entity &)> f) {
     accessor acc;
     if (_entities.find(acc, id)) {
       f(acc->second);
@@ -146,7 +158,7 @@ public:
   /// @brief  Returns true if the entity is registered in the registry.
   /// @param id
   /// @return true if the entity is registered, false otherwise.
-  inline bool IsEntityRegistered(const std::string &id) {
+  bool IsEntityRegistered(const std::string &id) {
     accessor acc;
     return _entities.find(acc, id);
   }

--- a/system/include/Entity.hpp
+++ b/system/include/Entity.hpp
@@ -23,9 +23,7 @@ struct Entity {
       ettNativeHandle; ///< The entity's native handle used to
                        ///< interact with the engine.
 
-#ifdef CELTE_SERVER_MODE_ENABLED
   std::string payload; ///< customdata that can be set by the game dev to help
                        ///< other peers loading the entity
-#endif
 };
 } // namespace celte

--- a/system/include/GhostSystem.hpp
+++ b/system/include/GhostSystem.hpp
@@ -16,8 +16,7 @@ class GhostSystem {
 public:
   struct PropertyInfo {
     std::string value;
-    Clock::timepoint lastSync;
-    Clock::timepoint lastChange;
+    bool synced = false;
   };
 
   struct Properties {

--- a/system/include/GrapeRegistry.hpp
+++ b/system/include/GrapeRegistry.hpp
@@ -196,6 +196,14 @@ public:
     return std::nullopt;
   }
 
+  inline std::vector<std::string> GetKnownGrapes() {
+    std::vector<std::string> grapes;
+    for (auto it = _grapes.begin(); it != _grapes.end(); ++it) {
+      grapes.push_back(it->first);
+    }
+    return grapes;
+  }
+
 private:
   tbb::concurrent_hash_map<std::string, Grape> _grapes;
 };

--- a/system/include/GrapeRegistry.hpp
+++ b/system/include/GrapeRegistry.hpp
@@ -84,8 +84,6 @@ public:
     accessor acc;
     if (_grapes.find(acc, grapeId)) {
       f(acc->second);
-    } else {
-      std::cout << "Grape not found: " << grapeId << std::endl;
     }
   }
 
@@ -95,8 +93,6 @@ public:
     accessor acc;
     if (_grapes.find(acc, grapeId)) {
       (instance->*memberFunc)(acc->second);
-    } else {
-      std::cout << "Grape not found: " << grapeId << std::endl;
     }
   }
 
@@ -106,8 +102,6 @@ public:
     accessor acc;
     if (_grapes.find(acc, grapeId)) {
       (instance->*memberFunc)(acc->second, args...);
-    } else {
-      std::cout << "Grape not found: " << grapeId << std::endl;
     }
   }
 
@@ -146,7 +140,8 @@ public:
                                        std::function<void()> onReady,
                                        const std::string &id = "");
 
-  void SetRemoteGrapeSubscription(const std::string &grapeId,
+  void SetRemoteGrapeSubscription(const std::string &ownerOfContainerId,
+                                  const std::string &grapeId,
                                   const std::string &containerId,
                                   bool subscribe);
 

--- a/system/include/HookTable.hpp
+++ b/system/include/HookTable.hpp
@@ -22,8 +22,8 @@ struct HookTable {
   /// client should connect to a grape in order to be able to load the map and
   /// start playing.
   /// @param clientId The unique identifier of the client.
-  std::function<std::string(const std::string &)> onAcceptNewClient =
-      UNIMPLEMENTED<std::string, const std::string &>;
+  std::function<void(const std::string &)> onAcceptNewClient =
+      UNIMPLEMENTED<void, const std::string &>;
 
   std::function<void(const std::string &)> onClientRequestDisconnect =
       UNIMPLEMENTED<void, const std::string &>;
@@ -36,13 +36,14 @@ struct HookTable {
 
   /// @brief Called when a client disconnects from the cluster.
   /// @param clientId The unique identifier of the client.
-  std::function<void(std::string, std::string)> onClientDisconnect =
-      UNIMPLEMENTED<void, std::string, std::string>;
+  std::function<void(const std::string &, const std::string &)>
+      onClientDisconnect =
+          UNIMPLEMENTED<void, const std::string &, const std::string &>;
 
   /// @brief Called when a grape is loaded (the game should load the map and the
   /// CSN object associated with it).
-  std::function<void(std::string, bool)> onLoadGrape =
-      UNIMPLEMENTED<void, std::string, bool>;
+  std::function<void(const std::string &, bool)> onLoadGrape =
+      UNIMPLEMENTED<void, const std::string &, bool>;
 
   /// @brief Called when the connection to the cluster is unsuccessful.
   std::function<void()> onConnectionFailed = UNIMPLEMENTED<void>;
@@ -51,14 +52,15 @@ struct HookTable {
   std::function<void()> onConnectionSuccess = UNIMPLEMENTED<void>;
 
   /// @brief Called when an entity has to be instantiated in the engine.
-  std::function<void(std::string, std::string)> onInstantiateEntity =
-      UNIMPLEMENTED<void, std::string, std::string>;
+  std::function<void(const std::string &, const std::string &)>
+      onInstantiateEntity =
+          UNIMPLEMENTED<void, const std::string &, const std::string &>;
 
   /// @brief Called when an entity has to be deleted in the engine.
   /// @param entityId The unique identifier of the entity.
   /// @param payload The payload of the entity.
-  std::function<void(std::string, std::string)> onDeleteEntity =
-      UNIMPLEMENTED<void, std::string, std::string>;
+  std::function<void(const std::string &, const std::string &)> onDeleteEntity =
+      UNIMPLEMENTED<void, const std::string &, const std::string &>;
 
   /* ----------------------------- ERROR HANDLERS -----------------------------
    */

--- a/system/include/MetricsScrapper.hpp
+++ b/system/include/MetricsScrapper.hpp
@@ -44,8 +44,6 @@ public:
   /// @param getter
   template <typename T>
   void RegisterMetric(const std::string &name, std::function<T()> getter) {
-    std::cout << "registered metric with name: " << name << std::endl;
-    std::cout << "this is " << this << std::endl;
     std::lock_guard<std::mutex> lock(_metricsMutex);
     _metrics[name] = [getter]() {
       std::array<char, 64> buffer;

--- a/system/include/PeerService.hpp
+++ b/system/include/PeerService.hpp
@@ -38,6 +38,9 @@ public:
                                   const std::string &containerId,
                                   std::function<void()> then);
 
+  void UnsubscribeClientFromContainer(const std::string &clientId,
+                                      const std::string &containerId);
+
   inline ClientRegistry &GetClientRegistry() { return _clientRegistry; }
 
 #endif
@@ -78,6 +81,8 @@ private:
   /// still alive.
   /// @note the bool argument is not used, it is just a placeholder to make the
   /// rpc call.
+
+  bool __rp_unsubscribeClientFromContainer(const std::string &containerId);
   bool __rp_ping();
 #endif
   /* ------------------------------- SERVER RPC

--- a/system/include/PeerService.hpp
+++ b/system/include/PeerService.hpp
@@ -6,6 +6,7 @@
 #include "RPCService.hpp"
 #include "WriterStreamPool.hpp"
 #include <functional>
+#include <map>
 
 using namespace std::chrono_literals;
 
@@ -45,6 +46,11 @@ public:
 
 #endif
 
+  /// @brief If the peer is a client returns a map of the latencies (ms) to each
+  /// of the known server nodes in the cluster.
+  /// @return
+  std::map<std::string, int> GetLatency();
+
 private:
   /// @brief Waits for the network of the rpc service to be ready
   /// @param connectionTimeout The time to wait for the network to be ready
@@ -83,8 +89,9 @@ private:
   /// rpc call.
 
   bool __rp_unsubscribeClientFromContainer(const std::string &containerId);
-  bool __rp_ping();
 #endif
+
+  bool __rp_ping();
   /* ------------------------------- SERVER RPC
    * -------------------------------
    */

--- a/system/include/ReaderStream.hpp
+++ b/system/include/ReaderStream.hpp
@@ -97,10 +97,12 @@ struct ReaderStream {
           PendingRefCount prc(
               _pendingMessages); // RAII counter for pending handler messages.
           if (_closed) {
+            consumer.acknowledge(msg);
             return;
           }
           // if consumer is closed, don't handle the message
           if (not consumer.isConnected()) {
+            consumer.acknowledge(msg);
             return;
           }
           Req req;
@@ -108,7 +110,7 @@ struct ReaderStream {
                            msg.getLength());
 
           // { // don't remove this if its commented, someone will use it
-          //   // debug
+          //   // debugrea;a
           //   if (msg.getTopicName().find("global.clock") == std::string::npos)
           //     std::cout << "[[ReaderStream]] handling message " << data
           //               << " from topic " << msg.getTopicName() << std::endl;
@@ -116,6 +118,7 @@ struct ReaderStream {
 
           if (!google::protobuf::util::JsonStringToMessage(data, &req).ok()) {
             std::cerr << "Error parsing message: " << data << std::endl;
+            consumer.acknowledge(msg);
             return;
           }
           if (options.messageHandler)

--- a/system/include/Runtime.hpp
+++ b/system/include/Runtime.hpp
@@ -4,6 +4,7 @@
 #include "ETTRegistry.hpp"
 #include "HookTable.hpp"
 #include "Logger.hpp"
+#include "TrashBin.hpp"
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -83,6 +84,9 @@ public:
     return _asyncIOTaskScheduler;
   }
 
+  /// @brief Returns the trash bin of the system.
+  inline TrashBin &GetTrashBin() { return _trashBin; }
+
   /// @brief Returns the unique identifier of this peer on the network.
   inline const std::string &GetUUID() const { return _uuid; }
 
@@ -141,6 +145,7 @@ private:
   HookTable _hooks;
   std::unique_ptr<PeerService> _peerService;
   Config _config;
+  TrashBin _trashBin;
 
 #ifdef CELTE_SERVER_MODE_ENABLED
   std::string _assignedGrape;

--- a/system/include/TrashBin.hpp
+++ b/system/include/TrashBin.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <memory>
+
+namespace celte {
+class TrashBin; // forward declaration
+class ITrashable {
+public:
+  /// @brief Virtual destructor to ensure proper cleanup of derived classes.
+  virtual ~ITrashable() = default;
+
+protected:
+  /// @brief Starts the cleanup process of the object. This method should block
+  /// until the object can safely be deleted.
+  /// @warning This method MUST be thread safe.
+  virtual void __cleanup() = 0;
+
+  friend TrashBin;
+};
+
+/// @brief The TrashBin class is used to store objects scheduled for deletion
+/// until they have been cleaned up and can be deleted correctly.
+class TrashBin {
+public:
+  /// @brief Sends an item to the trash bin. Takes ownership of the item, which
+  /// will no longer be usable by the previous owner. The item will be deleted
+  /// when all of its resources have been cleaned up.
+  /// @note The item must inherit publicly from the ITrashable class.
+  /// @param item
+  template <typename T>
+  typename std::enable_if<std::is_base_of<ITrashable, T>::value>::type
+  TrashItem(T &&item) {
+    auto ptr = std::make_shared<T>(std::move(item));
+    __asyncCleanup(std::move(ptr));
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_base_of<ITrashable, T>::value>::type
+  TrashItem(std::shared_ptr<T> item) {
+    __asyncCleanup(std::move(item));
+  }
+
+  void TrashItem(ITrashable *item);
+
+private:
+  /// @brief Asynchronously starts cleaning up an object, whose destructor will
+  /// be called after the cleanup is done.
+  void __asyncCleanup(std::shared_ptr<ITrashable> item);
+};
+} // namespace celte

--- a/system/server_src/ClientRegistry.cpp
+++ b/system/server_src/ClientRegistry.cpp
@@ -50,6 +50,5 @@ void ClientRegistry::ForgetClient(const std::string &clientId) {
 }
 
 void ClientRegistry::DisconnectClient(const std::string &clientId) {
-  std::cout << "Disconnecting client " << clientId << std::endl;
   std::cout << "NOT IMPLEMENTED" << std::endl;
 }


### PR DESCRIPTION
## PR Checklist:

- [x] I have linked the issue to the epic and milestone.
- [x] I have reviewed my code, removed all unnecessary comments, and followed the coding style for each language.
- [x] I have tested my code with the rest of the new feature before pushing it.
- [x] I have updated the documentation if necessary.

---

## Description:

Celte godot api now provides bindings for the game developer to subscribe clients / servers  to containers. Both clients and servers are now capable to unload containers that are no longer relevant, and load them again when they become relevant again.

## Changes:

See above. 
Good amount of fixes concerning property replication, as well as some debug in godot (access to client latency)

## Testing:

up pulsar, redis, master, 2 servers, 2 clients
move around, confirm that nothing crazy happens

## Expected Results:

Servers now don't have to work more than necessary.