### PR TITLE
feat: Implement Runtime destructor and cleanup hooks functionality

### DIFF
--- a/system/common_src/Runtime.cpp
+++ b/system/common_src/Runtime.cpp
@@ -40,6 +40,11 @@ Runtime::Runtime() : _uuid(make_uuid()) {
   std::cout << "Process PID: " << getpid() << std::endl;
 }
 
+Runtime::~Runtime() {
+  std::cout << "Runtime destructor called, clearing hooks" << std::endl;
+  ResetHooks();
+}
+
 Runtime &Runtime::GetInstance() {
   static Runtime instance;
   return instance;

--- a/system/common_src/exports.cpp
+++ b/system/common_src/exports.cpp
@@ -503,6 +503,8 @@ EXPORT void SetOnDeleteEntityHook(
   RUNTIME.Hooks().onDeleteEntity = f;
 }
 
+EXPORT void CelteCleanup() { RUNTIME.ResetHooks(); }
+
 EXPORT void UploadInputData(const std::string &uuid,
                             const std::string &inputName, bool pressed,
                             float x = 0, float y = 0) {

--- a/system/include/HookTable.hpp
+++ b/system/include/HookTable.hpp
@@ -3,23 +3,59 @@
 #include <iostream>
 #include <string>
 
+// HookInvoker stores a heap-allocated std::function and forwards calls/assigns
+// to it. The underlying std::function is intentionally leaked to avoid
+// destructor-order crashes during shared-library unload / static teardown.
+template <typename Sig> struct HookInvoker;
+
+template <typename Ret, typename... Args> struct HookInvoker<Ret(Args...)> {
+  using Fn = std::function<Ret(Args...)>;
+
+  HookInvoker() {
+    func = new Fn(
+        [](Args...) -> Ret { throw std::runtime_error("Missing hook"); });
+  }
+  explicit HookInvoker(Fn f) { func = new Fn(std::move(f)); }
+
+  // forward call
+  Ret operator()(Args... args) const {
+    return (*func)(std::forward<Args>(args)...);
+  }
+
+  // assign new callable into the existing heap object
+  HookInvoker &operator=(const Fn &f) {
+    *func = f;
+    return *this;
+  }
+  HookInvoker &operator=(Fn &&f) {
+    *func = std::move(f);
+    return *this;
+  }
+
+  // allow taking the stored function by value if needed
+  Fn as_function() const { return *func; }
+
+  // pointer to heap-allocated std::function (intentionally not deleted). Use
+  // exported API function CelteCleanup to delete all hooks at once when
+  // unloading the shared.
+  Fn *func;
+};
+
 template <typename Ret, typename... Args>
-std::function<Ret(Args...)> UNIMPLEMENTED =
-    [](Args...) -> Ret { throw std::runtime_error("Missing hook"); };
+inline std::function<Ret(Args...)> make_unimplemented() {
+  return std::function<Ret(Args...)>(
+      [](Args...) -> Ret { throw std::runtime_error("Missing hook"); });
+}
 
 namespace celte {
 struct HookTable {
-
 #ifdef CELTE_SERVER_MODE_ENABLED // server only hooks
 
-  std::function<void(const std::string &)>
-      onServerReceivedInitializationPayload =
-          UNIMPLEMENTED<void, const std::string &>;
+  HookInvoker<void(const std::string &)> onServerReceivedInitializationPayload;
 
   /// @brief Called by the master when a lcient connects to the cluster, to get
   /// the name of the grape that the client should be connecting to.
-  std::function<std::string(const std::string &)> onGetClientInitialGrape =
-      UNIMPLEMENTED<std::string, const std::string &>;
+  HookInvoker<std::string(const std::string &)> onGetClientInitialGrape;
 
   /// @brief Called when a new client is accepted by the server.
   /// The game developer is free to handle this as they see fit. Eventually, the
@@ -27,63 +63,51 @@ struct HookTable {
   /// start playing.
   /// @param clientId The unique identifier of the client.
   /// @param spawnerId The unique identifier of the grape that spawned the
-  std::function<void(const std::string &, const std::string &)>
-      onAcceptNewClient =
-          UNIMPLEMENTED<void, const std::string &, const std::string &>;
+  HookInvoker<void(const std::string &, const std::string &)> onAcceptNewClient;
 
-  std::function<void(const std::string &)> onClientRequestDisconnect =
-      UNIMPLEMENTED<void, const std::string &>;
+  HookInvoker<void(const std::string &)> onClientRequestDisconnect;
 
-  std::function<void(const std::string &)> onClientNotSeen =
-      UNIMPLEMENTED<void, const std::string &>;
+  HookInvoker<void(const std::string &)> onClientNotSeen;
 
 #else  // client only hooks
 #endif // all peers hooks
 
   /// @brief Called when a client disconnects from the cluster.
   /// @param clientId The unique identifier of the client.
-  std::function<void(const std::string &, const std::string &)>
-      onClientDisconnect =
-          UNIMPLEMENTED<void, const std::string &, const std::string &>;
+  HookInvoker<void(const std::string &, const std::string &)>
+      onClientDisconnect;
 
   /// @brief Called when a grape is loaded (the game should load the map and the
   /// CSN object associated with it).
-  std::function<void(const std::string &, bool)> onLoadGrape =
-      UNIMPLEMENTED<void, const std::string &, bool>;
+  HookInvoker<void(const std::string &, bool)> onLoadGrape;
 
   /// @brief Called when the connection to the cluster is unsuccessful.
-  std::function<void()> onConnectionFailed = UNIMPLEMENTED<void>;
+  HookInvoker<void()> onConnectionFailed;
 
   /// @brief Called when the connection to the cluster is successful.
-  std::function<void()> onConnectionSuccess = UNIMPLEMENTED<void>;
+  HookInvoker<void()> onConnectionSuccess;
 
   /// @brief Called when an entity has to be instantiated in the engine.
-  std::function<void(const std::string &, const std::string &)>
-      onInstantiateEntity =
-          UNIMPLEMENTED<void, const std::string &, const std::string &>;
+  HookInvoker<void(const std::string &, const std::string &)>
+      onInstantiateEntity;
 
   /// @brief Called when an entity has to be deleted in the engine.
   /// @param entityId The unique identifier of the entity.
   /// @param payload The payload of the entity.
-  std::function<void(const std::string &, const std::string &)> onDeleteEntity =
-      UNIMPLEMENTED<void, const std::string &, const std::string &>;
+  HookInvoker<void(const std::string &, const std::string &)> onDeleteEntity;
 
   /* ----------------------------- ERROR HANDLERS -----------------------------
    */
 
   /// @brief Called when an RPC call times out.
-  std::function<void(const std::string &)> onRPCTimeout =
-      [](const std::string &s) {
-        std::cerr << "RPC call timed out: " << s
-                  << std::endl; // actual logging is done automatically by the
-                                // CelteError class
-      };
+  HookInvoker<void(const std::string &)> onRPCTimeout =
+      HookInvoker<void(const std::string &)>([](const std::string &s) {
+        std::cerr << "RPC call timed out: " << s << std::endl;
+      });
 
-  std::function<void(const std::string &)> onRPCHandlingError =
-      [](const std::string &s) {
-        std::cerr << "Error handling RPC: " << s
-                  << std::endl; // actual logging is done automatically by the
-                                // CelteError class
-      };
+  HookInvoker<void(const std::string &)> onRPCHandlingError =
+      HookInvoker<void(const std::string &)>([](const std::string &s) {
+        std::cerr << "Error handling RPC: " << s << std::endl;
+      });
 };
 } // namespace celte

--- a/system/include/Runtime.hpp
+++ b/system/include/Runtime.hpp
@@ -23,6 +23,7 @@ class Runtime {
 public:
   static Runtime &GetInstance();
   Runtime();
+  ~Runtime();
   /* ---------------------- FUNCTIONS EXPOSED TO THE API
    * ----------------------
    */
@@ -113,6 +114,11 @@ public:
 
   /// @brief Returns the hook table.
   inline HookTable &Hooks() { return _hooks; }
+
+  /// @brief Clears all registered hooks, replacing them with default no-op
+  /// handlers. Call this from the embedding (e.g., Godot) before unloading the
+  /// library to avoid destructor-time callback crashes.
+  inline void ResetHooks() { _hooks = HookTable(); }
 
   /// @brief Returns the peer service.
   /// @throws std::runtime_error if the peer service is not initialized.


### PR DESCRIPTION
Fixed crash when Godot editor exits by updating hooktable and removing static deletion
see CLT-50 branch on celte-godot